### PR TITLE
create log directory

### DIFF
--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -x
 
-#source /usr/local/bootstrap/var.env
-
 IFACE=`route -n | awk '$1 == "192.168.5.0" {print $8;exit}'`
 CIDR=`ip addr show ${IFACE} | awk '$2 ~ "192.168.5" {print $2}'`
 IP=${CIDR%%/24}
 LOG="/vagrant/logs/consul_${HOSTNAME}.log"
+
+mkdir -p /vagrant/logs
 
 PKG="wget unzip"
 which ${PKG} &>/dev/null || {


### PR DESCRIPTION
# Why is the PR required?
## Issue: /vagrant/logs/ directory not created during fresh installation
## Refactor:
## New Feature:

# What do this PR do?
Fix initial installation issue

# How was this PR implemented?
create a /vagrant/logs directory before use

# How long did it take?
3 minutes

